### PR TITLE
Update wrapper's display attribute on resize

### DIFF
--- a/jquery.hc-sticky.js
+++ b/jquery.hc-sticky.js
@@ -489,7 +489,7 @@
 				var onResize = function() {
 					
 					// check if display attribute has changed due to css media queries
-					$wrapper.css({'display': '');
+					$wrapper.css({'display': ''});
                                         var display = $wrapper.css('display');
                                         $wrapper.css({'display': display});
 

--- a/jquery.hc-sticky.js
+++ b/jquery.hc-sticky.js
@@ -487,7 +487,7 @@
 					$resize_clone = false;
 
 				var onResize = function() {
-					
+
 					// check if display attribute has changed due to css media queries
 					$wrapper.css({'display': ''});
                                         var display = $wrapper.css('display');

--- a/jquery.hc-sticky.js
+++ b/jquery.hc-sticky.js
@@ -487,6 +487,11 @@
 					$resize_clone = false;
 
 				var onResize = function() {
+					
+					// check if display attribute has changed due to css media queries
+					$wrapper.css({'display': '');
+                                        var display = $wrapper.css('display');
+                                        $wrapper.css({'display': display});
 
 					// check if sticky is attached to scroll event
 					attachScroll();


### PR DESCRIPTION
When I applied hcSticky on an element that had a `display: none;` css rule for small screens (with media query), the following bug occured:
If I loaded the page while the window was small and increased the window size afterwards, the element was still invisible because of the inline `display: none;` style that hcSticky had applied to it.
Here's how I solved the problem.